### PR TITLE
Also check for code 429  (unsealed and standby)

### DIFF
--- a/service/handlers.go
+++ b/service/handlers.go
@@ -108,7 +108,7 @@ func (h handler) healthCheck(w http.ResponseWriter, r *http.Request) {
 		level.Error(h.logger).Log("message", fmt.Sprintf("received error connecting to vault endpoint %s", vaultEndpoint))
 		h.errorResponse(w, "Health check failed", http.StatusServiceUnavailable, err)
 	} else if response.StatusCode != 200 && response.StatusCode != 429 {
-		level.Error(h.logger).Log("message", fmt.Sprintf("received code %s which is not 200 (initialized, unsealed, and active) or 429 (unsealed and standby) when connecting to vault endpoint %s", response.StatusCode, vaultEndpoint))
+		level.Error(h.logger).Log("message", fmt.Sprintf("received code %d which is not 200 (initialized, unsealed, and active) or 429 (unsealed and standby) when connecting to vault endpoint %s", response.StatusCode, vaultEndpoint))
 		h.errorResponse(w, "Health check failed", http.StatusServiceUnavailable, err)
 	} else {
 		fmt.Fprintln(w, "Health check succeeded")


### PR DESCRIPTION
Per vault documentation we should check for 429 also. We may want to check for additional codes such as 472 or 473.

200 if initialized, unsealed, and active
429 if unsealed and standby
472 if disaster recovery mode replication secondary and active
473 if performance standby
501 if not initialized
503 if sealed

https://www.vaultproject.io/api/system/health