### PR TITLE
small non breaking rename changes in code/lint config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,7 +16,7 @@ linters:
     - wastedassign
 linters-settings:
   goimports:
-    local-prefixes: github.com/argoproj-labs/argo-cloudops
+    local-prefixes: github.com/cello-proj/cello
 
   errcheck:
     exclude: .errcheck_excludes.txt

--- a/internal/requests/requests_test.go
+++ b/internal/requests/requests_test.go
@@ -21,7 +21,7 @@ func TestCreateWorkflowValidate(t *testing.T) {
 			req: CreateWorkflow{
 				Framework: "cdk",
 				Parameters: map[string]string{
-					"execute_container_image_uri": "argoproj-labs/argo-cloudops-exec",
+					"execute_container_image_uri": "cello-proj/cello-exec",
 				},
 				ProjectName:          "project1",
 				TargetName:           "target1",
@@ -41,8 +41,8 @@ func TestCreateWorkflowValidate(t *testing.T) {
 				},
 				Framework: "cdk",
 				Parameters: map[string]string{
-					"execute_container_image_uri": "argoproj-labs/argo-cloudops-exec",
-					"pre_container_image_uri":     "argoproj-labs/argo-cloudops-pre",
+					"execute_container_image_uri": "cello-proj/cello-exec",
+					"pre_container_image_uri":     "cello-proj/cello-pre",
 				},
 				ProjectName:          "project1",
 				TargetName:           "target1",
@@ -55,7 +55,7 @@ func TestCreateWorkflowValidate(t *testing.T) {
 			req: CreateWorkflow{
 				Framework: "cdk",
 				Parameters: map[string]string{
-					"execute_container_image_uri": "argoproj-labs/argo-cloudops-exec",
+					"execute_container_image_uri": "cello-proj/cello-exec",
 				},
 				ProjectName:          "project1",
 				TargetName:           "target1",
@@ -73,7 +73,7 @@ func TestCreateWorkflowValidate(t *testing.T) {
 				},
 				Framework: "cdk",
 				Parameters: map[string]string{
-					"execute_container_image_uri": "argoproj-labs/argo-cloudops-exec",
+					"execute_container_image_uri": "cello-proj/cello-exec",
 				},
 				ProjectName:          "project1",
 				TargetName:           "target1",
@@ -91,7 +91,7 @@ func TestCreateWorkflowValidate(t *testing.T) {
 				},
 				Framework: "cdk",
 				Parameters: map[string]string{
-					"execute_container_image_uri": "argoproj-labs/argo-cloudops-exec",
+					"execute_container_image_uri": "cello-proj/cello-exec",
 				},
 				ProjectName:          "project1",
 				TargetName:           "target1",
@@ -108,7 +108,7 @@ func TestCreateWorkflowValidate(t *testing.T) {
 				},
 				Framework: "cdk",
 				Parameters: map[string]string{
-					"execute_container_image_uri": "argoproj-labs/argo-cloudops-exec",
+					"execute_container_image_uri": "cello-proj/cello-exec",
 				},
 				ProjectName:          "project1",
 				TargetName:           "target1",
@@ -124,7 +124,7 @@ func TestCreateWorkflowValidate(t *testing.T) {
 				},
 				Framework: "cdk",
 				Parameters: map[string]string{
-					"execute_container_image_uri": "argoproj-labs/argo-cloudops-exec",
+					"execute_container_image_uri": "cello-proj/cello-exec",
 				},
 				ProjectName:          "project1",
 				TargetName:           "target1",
@@ -148,7 +148,7 @@ func TestCreateWorkflowValidate(t *testing.T) {
 			req: CreateWorkflow{
 				Framework: "cdk",
 				Parameters: map[string]string{
-					"pre_container_image_uri": "argoproj-labs/argo-cloudops-pre",
+					"pre_container_image_uri": "cello-proj/cello-pre",
 				},
 				ProjectName:          "project1",
 				TargetName:           "target1",
@@ -176,7 +176,7 @@ func TestCreateWorkflowValidate(t *testing.T) {
 			req: CreateWorkflow{
 				Framework: "cdk",
 				Parameters: map[string]string{
-					"execute_container_image_uri": "argoproj-labs/argo-cloudops-exec",
+					"execute_container_image_uri": "cello-proj/cello-exec",
 					"pre_container_image_uri":     "./foo/bar",
 				},
 				ProjectName:          "project1",
@@ -191,7 +191,7 @@ func TestCreateWorkflowValidate(t *testing.T) {
 			req: CreateWorkflow{
 				Framework: "cdk",
 				Parameters: map[string]string{
-					"execute_container_image_uri": "badactor-labs/argo-cloudops-exec",
+					"execute_container_image_uri": "badactor-labs/cello-exec",
 				},
 				ProjectName:          "project1",
 				TargetName:           "target1",
@@ -205,8 +205,8 @@ func TestCreateWorkflowValidate(t *testing.T) {
 			req: CreateWorkflow{
 				Framework: "cdk",
 				Parameters: map[string]string{
-					"execute_container_image_uri": "argoproj-labs/argo-cloudops-exec",
-					"pre_container_image_uri":     "badactor-labs/argo-cloudops-exec",
+					"execute_container_image_uri": "cello-proj/cello-exec",
+					"pre_container_image_uri":     "badactor-labs/cello-exec",
 				},
 				ProjectName:          "project1",
 				TargetName:           "target1",
@@ -219,7 +219,7 @@ func TestCreateWorkflowValidate(t *testing.T) {
 			name: "missing framework",
 			req: CreateWorkflow{
 				Parameters: map[string]string{
-					"execute_container_image_uri": "argoproj-labs/argo-cloudops-exec",
+					"execute_container_image_uri": "cello-proj/cello-exec",
 				},
 				ProjectName:          "project1",
 				TargetName:           "target1",
@@ -233,7 +233,7 @@ func TestCreateWorkflowValidate(t *testing.T) {
 			req: CreateWorkflow{
 				Framework: "cdk",
 				Parameters: map[string]string{
-					"execute_container_image_uri": "argoproj-labs/argo-cloudops-exec",
+					"execute_container_image_uri": "cello-proj/cello-exec",
 				},
 				ProjectName:          "project1",
 				TargetName:           "target1",
@@ -246,7 +246,7 @@ func TestCreateWorkflowValidate(t *testing.T) {
 			req: CreateWorkflow{
 				Framework: "cdk",
 				Parameters: map[string]string{
-					"execute_container_image_uri": "argoproj-labs/argo-cloudops-exec",
+					"execute_container_image_uri": "cello-proj/cello-exec",
 				},
 				TargetName:           "target1",
 				Type:                 "diff",
@@ -259,7 +259,7 @@ func TestCreateWorkflowValidate(t *testing.T) {
 			req: CreateWorkflow{
 				Framework: "cdk",
 				Parameters: map[string]string{
-					"execute_container_image_uri": "argoproj-labs/argo-cloudops-exec",
+					"execute_container_image_uri": "cello-proj/cello-exec",
 				},
 				ProjectName:          "abc",
 				TargetName:           "target1",
@@ -273,7 +273,7 @@ func TestCreateWorkflowValidate(t *testing.T) {
 			req: CreateWorkflow{
 				Framework: "cdk",
 				Parameters: map[string]string{
-					"execute_container_image_uri": "argoproj-labs/argo-cloudops-exec",
+					"execute_container_image_uri": "cello-proj/cello-exec",
 				},
 				ProjectName:          "a12345678901234567890123456789012",
 				TargetName:           "target1",
@@ -287,7 +287,7 @@ func TestCreateWorkflowValidate(t *testing.T) {
 			req: CreateWorkflow{
 				Framework: "cdk",
 				Parameters: map[string]string{
-					"execute_container_image_uri": "argoproj-labs/argo-cloudops-exec",
+					"execute_container_image_uri": "cello-proj/cello-exec",
 				},
 				ProjectName:          "this-is-invalid",
 				TargetName:           "target1",
@@ -301,7 +301,7 @@ func TestCreateWorkflowValidate(t *testing.T) {
 			req: CreateWorkflow{
 				Framework: "cdk",
 				Parameters: map[string]string{
-					"execute_container_image_uri": "argoproj-labs/argo-cloudops-exec",
+					"execute_container_image_uri": "cello-proj/cello-exec",
 				},
 				ProjectName:          "project1",
 				Type:                 "diff",
@@ -314,7 +314,7 @@ func TestCreateWorkflowValidate(t *testing.T) {
 			req: CreateWorkflow{
 				Framework: "cdk",
 				Parameters: map[string]string{
-					"execute_container_image_uri": "argoproj-labs/argo-cloudops-exec",
+					"execute_container_image_uri": "cello-proj/cello-exec",
 				},
 				ProjectName:          "project1",
 				TargetName:           "abc",
@@ -328,7 +328,7 @@ func TestCreateWorkflowValidate(t *testing.T) {
 			req: CreateWorkflow{
 				Framework: "cdk",
 				Parameters: map[string]string{
-					"execute_container_image_uri": "argoproj-labs/argo-cloudops-exec",
+					"execute_container_image_uri": "cello-proj/cello-exec",
 				},
 				ProjectName:          "project1",
 				TargetName:           "a12345678901234567890123456789012",
@@ -342,7 +342,7 @@ func TestCreateWorkflowValidate(t *testing.T) {
 			req: CreateWorkflow{
 				Framework: "cdk",
 				Parameters: map[string]string{
-					"execute_container_image_uri": "argoproj-labs/argo-cloudops-exec",
+					"execute_container_image_uri": "cello-proj/cello-exec",
 				},
 				ProjectName:          "project1this",
 				TargetName:           "this-is-invalid",
@@ -356,7 +356,7 @@ func TestCreateWorkflowValidate(t *testing.T) {
 			req: CreateWorkflow{
 				Framework: "cdk",
 				Parameters: map[string]string{
-					"execute_container_image_uri": "argoproj-labs/argo-cloudops-exec",
+					"execute_container_image_uri": "cello-proj/cello-exec",
 					"pre_container_image_uri":     "./foo/bar",
 				},
 				ProjectName: "project1",
@@ -367,7 +367,7 @@ func TestCreateWorkflowValidate(t *testing.T) {
 		},
 	}
 
-	validations.SetImageURIs([]string{"argoproj-labs/*"})
+	validations.SetImageURIs([]string{"cello-proj/*"})
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/validations/validations.go
+++ b/internal/validations/validations.go
@@ -74,8 +74,8 @@ func IsValidImageURI(imageURI string) bool {
 // IsApprovedImageURI determines if the image URI is approved for use. Default is allow-all. Full filepath matching
 // rules are applied to allow varying levels of globbing and wildcards.
 // Examples:
-// - Direct match: docker.myco.com/argocloups/cdk:1234
-// - Direct image, any tag: docker.myco.com/argocloudops/cdk:*
+// - Direct match: docker.myco.com/cello/cdk:1234
+// - Direct image, any tag: docker.myco.com/cello/cdk:*
 // - Any image within a specific registry: docker.myco.com/*/*
 func IsApprovedImageURI(imageURI string) bool {
 	// default to allow all if no restrictions set

--- a/internal/validations/validations_test.go
+++ b/internal/validations/validations_test.go
@@ -91,7 +91,7 @@ func TestIsValidGitURI(t *testing.T) {
 		},
 		{
 			name:       "valid git",
-			testString: "git@github.com:argoproj-labs/argo-cloudops.git",
+			testString: "git@github.com:cello-proj/cello.git",
 			want:       true,
 		},
 		{
@@ -101,7 +101,7 @@ func TestIsValidGitURI(t *testing.T) {
 		},
 		{
 			name:       "invalid shorthand",
-			testString: "argoproj-labs/argo-cloudops",
+			testString: "cello-proj/cello",
 		},
 	}
 
@@ -120,12 +120,12 @@ func TestIsValidImageURI(t *testing.T) {
 	}{
 		{
 			name:       "valid execute container image",
-			testString: "argocloudops/argo-cloudops-cdk:1.87.1",
+			testString: "cello/cello-cdk:1.87.1",
 			want:       true,
 		},
 		{
 			name:       "invalid execute container image",
-			testString: "()argocloudops  -- /argo-cloudops-cdk:1.87.1",
+			testString: "()cello  -- /cello-cdk:1.87.1",
 		},
 		{
 			name: "no image provided",
@@ -148,36 +148,36 @@ func TestIsApprovedImageURI(t *testing.T) {
 	}{
 		{
 			name:       "default allow-all passes",
-			testString: "argocloudops/argo-cloudops-cdk:1.87.1",
+			testString: "cello/cello-cdk:1.87.1",
 			want:       true,
 		},
 		{
 			name:       "default allow-all passes with multi-separator",
-			testString: "docker.myco.com/slash1/argo-cloudops/slash2/argo-cloudops-cdk:latest",
+			testString: "docker.myco.com/slash1/cello/slash2/cello-cdk:latest",
 			want:       true,
 			uris:       []string{},
 		},
 		{
 			name:       "direct matched image from config passes",
-			testString: "argocloudops/match:1.87.1",
+			testString: "cello/match:1.87.1",
 			want:       true,
-			uris:       []string{"argocloudops/match:1.87.1"},
+			uris:       []string{"cello/match:1.87.1"},
 		},
 		{
 			name:       "rejects non-approved image",
-			testString: "argocloudops/nomatch:1.87.1",
+			testString: "cello/nomatch:1.87.1",
 			want:       false,
-			uris:       []string{"argocloudops/match:1.87.1"},
+			uris:       []string{"cello/match:1.87.1"},
 		},
 		{
 			name:       "matches globbing on tag",
-			testString: "argocloudops/match:1.87.1",
+			testString: "cello/match:1.87.1",
 			want:       true,
-			uris:       []string{"argocloudops/match:*"},
+			uris:       []string{"cello/match:*"},
 		},
 		{
 			name:       "matches globbing on any image within a registry",
-			testString: "docker.myco.com/argocloudops/match:1.87.1",
+			testString: "docker.myco.com/cello/match:1.87.1",
 			want:       true,
 			uris:       []string{"docker.myco.com/*/*"},
 		},

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -483,7 +483,7 @@ func (h handler) getWorkflowLogStream(w http.ResponseWriter, r *http.Request) {
 }
 
 // Returns a new token
-func newArgoCloudOpsToken(provider, key, secret string) *token {
+func newCelloToken(provider, key, secret string) *token {
 	return &token{
 		Token: fmt.Sprintf("%s:%s:%s", provider, key, secret),
 	}
@@ -566,7 +566,7 @@ func (h handler) createProject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	level.Debug(l).Log("message", "retrieving Cello token")
-	t := newArgoCloudOpsToken("vault", role, secret)
+	t := newCelloToken("vault", role, secret)
 	jsonResult, err := json.Marshal(t)
 	if err != nil {
 		level.Error(l).Log("message", "error serializing token", "error", err)


### PR DESCRIPTION
- [x] updated golangci lint rule to use new repo
- [x] update nonbreaking tests/comments containing argo cloudops to use cello instead
- [x] update nonbreaking function names to use cello