### PR TITLE
update text strings and copy argo-cloudops workflow to cello

### DIFF
--- a/cli/internal/api/api_test.go
+++ b/cli/internal/api/api_test.go
@@ -934,6 +934,6 @@ var (
 		ProjectName:          "project1",
 		TargetName:           "target1",
 		Type:                 "sync",
-		WorkflowTemplateName: "argo-cloudops-single-step-vault-aws",
+		WorkflowTemplateName: "cello-single-step-vault-aws",
 	}
 )

--- a/cli/internal/api/testdata/execute_workflow_good.json
+++ b/cli/internal/api/testdata/execute_workflow_good.json
@@ -1,9 +1,6 @@
 {
   "arguments": {
-    "execute": [
-      "--no-color",
-      "--require-approval never"
-    ]
+    "execute": ["--no-color", "--require-approval never"]
   },
   "environment_variables": {
     "AWS_REGION": "us-west-2",
@@ -17,5 +14,5 @@
   "project_name": "project1",
   "target_name": "target1",
   "type": "sync",
-  "workflow_template_name": "argo-cloudops-single-step-vault-aws"
+  "workflow_template_name": "cello-single-step-vault-aws"
 }

--- a/docs/developers/api.md
+++ b/docs/developers/api.md
@@ -198,7 +198,7 @@ Request Body
   "project_name": "project1",
   "target_name": "target1",
   "type": "sync",
-  "workflow_template_name": "argo-cloudops-single-step-vault-aws"
+  "workflow_template_name": "cello-single-step-vault-aws"
 }
 ```
 

--- a/manifests/cdk_manifest.yaml
+++ b/manifests/cdk_manifest.yaml
@@ -11,4 +11,4 @@ parameters:
 project_name: project1
 target_name: target1
 type: diff
-workflow_template_name: argo-cloudops-single-step-vault-aws
+workflow_template_name: cello-single-step-vault-aws

--- a/manifests/kube_cdk_manifest.yaml
+++ b/manifests/kube_cdk_manifest.yaml
@@ -11,5 +11,5 @@ parameters:
 project_name: project1
 target_name: target1
 type: diff
-workflow_template_name: argo-cloudops-single-step-vault-aws
+workflow_template_name: cello-single-step-vault-aws
 

--- a/manifests/kube_terraform_manifest.yaml
+++ b/manifests/kube_terraform_manifest.yaml
@@ -13,5 +13,5 @@ parameters:
 project_name: project1
 target_name: target1
 type: diff
-workflow_template_name: argo-cloudops-single-step-vault-aws
+workflow_template_name: cello-single-step-vault-aws
 

--- a/manifests/terraform_manifest.yaml
+++ b/manifests/terraform_manifest.yaml
@@ -13,4 +13,4 @@ parameters:
 project_name: project1
 target_name: target1
 type: diff
-workflow_template_name: argo-cloudops-single-step-vault-aws
+workflow_template_name: cello-single-step-vault-aws

--- a/service/testdata/TestCreateWorkflow/can_create_workflow_request.json
+++ b/service/testdata/TestCreateWorkflow/can_create_workflow_request.json
@@ -12,5 +12,5 @@
   "project_name": "projectalreadyexists",
   "target_name": "TARGET_EXISTS",
   "type": "sync",
-  "workflow_template_name": "argo-cloudops-single-step-vault-aws"
+  "workflow_template_name": "cello-single-step-vault-aws"
 }

--- a/service/testdata/TestCreateWorkflow/fails_to_create_workflow_when_not_admin.json
+++ b/service/testdata/TestCreateWorkflow/fails_to_create_workflow_when_not_admin.json
@@ -12,5 +12,5 @@
   "project_name": "projectalreadyexists",
   "target_name": "TARGET_ALREADY_EXISTS",
   "type": "sync",
-  "workflow_template_name": "argo-cloudops-single-step-vault-aws"
+  "workflow_template_name": "cello-single-step-vault-aws"
 }

--- a/service/testdata/TestCreateWorkflow/framework_must_be_valid_request.json
+++ b/service/testdata/TestCreateWorkflow/framework_must_be_valid_request.json
@@ -6,12 +6,11 @@
     "foobar": "barfoo"
   },
   "framework": "FOOBAR",
-  "parameters" : {
+  "parameters": {
     "execute_container_image_uri": "argocloudops/argo-cloudops-cdk:1.87.1"
   },
   "project_name": "PROJECT",
   "target_name": "TARGET",
   "type": "sync",
-  "workflow_template_name": "argo-cloudops-single-step-vault-aws"
+  "workflow_template_name": "cello-single-step-vault-aws"
 }
-

--- a/service/testdata/TestCreateWorkflow/project_must_exist.json
+++ b/service/testdata/TestCreateWorkflow/project_must_exist.json
@@ -6,11 +6,11 @@
     "foobar": "barfoo"
   },
   "framework": "cdk",
-  "parameters" : {
+  "parameters": {
     "execute_container_image_uri": "argocloudops/argo-cloudops-cdk:1.87.1"
   },
   "project_name": "PROJECT_DOES_NOT_EXIST",
   "target_name": "TARGET_ALREADY_EXISTS",
   "type": "sync",
-  "workflow_template_name": "argo-cloudops-single-step-vault-aws"
+  "workflow_template_name": "cello-single-step-vault-aws"
 }

--- a/service/testdata/TestCreateWorkflow/target_must_exist.json
+++ b/service/testdata/TestCreateWorkflow/target_must_exist.json
@@ -12,5 +12,5 @@
   "project_name": "projectalreadyexists",
   "target_name": "TARGET_DOES_NOT_EXIST",
   "type": "sync",
-  "workflow_template_name": "argo-cloudops-single-step-vault-aws"
+  "workflow_template_name": "cello-single-step-vault-aws"
 }

--- a/service/testdata/TestCreateWorkflow/type_must_be_valid_request.json
+++ b/service/testdata/TestCreateWorkflow/type_must_be_valid_request.json
@@ -6,12 +6,11 @@
     "foobar": "barfoo"
   },
   "framework": "cdk",
-  "parameters" : {
+  "parameters": {
     "execute_container_image_uri": "argocloudops/argo-cloudops-cdk:1.87.1"
   },
   "project_name": "PROJECT",
   "target_name": "TARGET",
   "type": "FOOBAR",
-  "workflow_template_name": "argo-cloudops-single-step-vault-aws"
+  "workflow_template_name": "cello-single-step-vault-aws"
 }
-

--- a/workflows/cello-single-step-vault-aws.yaml
+++ b/workflows/cello-single-step-vault-aws.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1 #argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: cello-single-step-vault-aws
+  labels:
+    workflows.argoproj.io/archive-strategy: "false"
+
+spec:
+  entrypoint: run
+  arguments:
+    parameters:
+    - name: credentials_token
+      value: ""
+    - name: environment_variables_string
+      value: ""
+    - name: execute_command
+      value: ""
+    - name: execute_container_image_uri
+      value: "set/by:service"
+    - name: project_name
+      value: ""
+    - name: target_name
+      value: ""
+
+  templates:
+  - name: run
+    steps:
+      - - name: execute
+          template: execute
+
+  - name: execute
+    container:
+      image: "{{workflow.parameters.execute_container_image_uri}}"
+      command: [sh, -c]
+      args: ["{{workflow.parameters.environment_variables_string}}
+                   bash /usr/local/bin/setup.sh
+                   {{workflow.parameters.credentials_token}}
+                   {{workflow.parameters.project_name}}
+                   {{workflow.parameters.target_name}}
+                   && {{workflow.parameters.execute_command}}"]


### PR DESCRIPTION
- [x] Makes a copy of the argo-cloudops-single-step-vault-aws.yaml workflow with the name cello-single-step-vault-aws.yaml
- [x] Updates tests to use cello instead of argo-cloudops
- [x] Updates manifests to use new workflow

Need this pr to be merged before commit shas, quickstart, instructions can be updated/the old workflow can be deleted