### PR TITLE
update cli to cello instead of argo cloudops

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,7 +23,7 @@ builds:
       # Don't use the default to avoid passing in 'BuildBy'.
       - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
   - id: cli
-    binary: argo-cloudops
+    binary: cello
     main: ./cli/
     env:
       - CGO_ENABLED=0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * Default workflow renamed from argo-cloudops-single-step-vault-aws.yaml to cello-single-step-vault-aws.yaml
 * Example manifests now point to cello-single-step-vault-aws workflow
+* Images moved to from argocloudops to celloproj
+* BREAKING cli binary renamed from argo-cloudops to cello
 
 ## [0.12.1] - 2022-03-14
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build_service: clean_service
 	CGO_ENABLED=0 GOARCH=amd64 go build -trimpath $(GO_LDFLAGS) -o build/service ./service/
 
 build_cli: clean_cli
-	CGO_ENABLED=0 GOARCH=amd64 go build -trimpath $(GO_LDFLAGS) -o build/argo-cloudops ./cli/
+	CGO_ENABLED=0 GOARCH=amd64 go build -trimpath $(GO_LDFLAGS) -o build/cello ./cli/
 
 lint:
 	@#Install the linter from here:
@@ -31,7 +31,7 @@ clean_service:
 	@rm -f ./build/service
 
 clean_cli:
-	@rm -f ./build/argo-cloudops
+	@rm -f ./build/cello
 
 up: ## Starts a local vault and api locally
 	bash scripts/start_local.sh dev

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -9,7 +9,7 @@ import (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "argo-cloudops",
+	Use:   "cello",
 	Short: "Cello Command Line Interface",
 	Long:  "Cello Command Line Interface",
 }

--- a/docs/cli/cello.md
+++ b/docs/cli/cello.md
@@ -1,9 +1,9 @@
-## argo-cloudops
+## cello
 
-argo-cloudops is the command line interface to Cello
+cello is the command line interface to Cello
 
 ```
-argo-cloudops [command]
+cello [command]
 ```
 
 ### Options
@@ -22,12 +22,12 @@ Available Commands:
   workflow    Creates a workflow execution with provided arguments
 
 Flags:
-  -h, --help   help for argo-cloudops
+  -h, --help   help for cello
 ```
 
 ### SEE ALSO
 
-* [argo-cloudops logs](argo-cloudops_logs.md) - gets logs from a workflow
+* [cello logs](cello_logs.md) - gets logs from a workflow
 
 
 

--- a/docs/cli/cello_diff.md
+++ b/docs/cli/cello_diff.md
@@ -1,15 +1,14 @@
-## argo-cloudops exec
-
-Executes an operation on a project target using a manifest in git
+## cello diff
+Diff a project target using a manifest in git
 
 ```
-  argo-cloudops exec [flags]
+  cello diff [flags]
 ```
 
 ### Flags
 
 ```
-  -h, --help                  help for exec
+  -h, --help                  help for diff
   -p, --path string           Path to manifest within git repository
   -n, --project_name string   Name of project
   -s, --sha string            Commit sha to use when creating workflow through git

--- a/docs/cli/cello_exec.md
+++ b/docs/cli/cello_exec.md
@@ -1,15 +1,15 @@
-## argo-cloudops sync
+## cello exec
 
-Syncs a project target using a manifest in git
+Executes an operation on a project target using a manifest in git
 
 ```
-  argo-cloudops sync [flags]
+  cello exec [flags]
 ```
 
 ### Flags
 
 ```
-  -h, --help                  help for sync
+  -h, --help                  help for exec
   -p, --path string           Path to manifest within git repository
   -n, --project_name string   Name of project
   -s, --sha string            Commit sha to use when creating workflow through git

--- a/docs/cli/cello_get.md
+++ b/docs/cli/cello_get.md
@@ -1,8 +1,8 @@
-## argo-cloudops get
+## cello get
 Gets status of workflow
 
 ```
-  argo-cloudops get [workflow name] [flags]
+  cello get [workflow name] [flags]
 ```
 
 ### Flags

--- a/docs/cli/cello_list.md
+++ b/docs/cli/cello_list.md
@@ -1,8 +1,8 @@
-## argo-cloudops list
+## cello list
 List workflow executions for a given project and target
 
 ```
-  argo-cloudops list [flags]
+  cello list [flags]
 ```
 
 ### Flags

--- a/docs/cli/cello_logs.md
+++ b/docs/cli/cello_logs.md
@@ -1,9 +1,9 @@
-## argo-cloudops logs
+## cello logs
 
 Gets logs from a workflow
 
 ```
-  argo-cloudops logs [workflow name] [flags]
+  cello logs [workflow name] [flags]
 ```
 
 ### Flags

--- a/docs/cli/cello_sync.md
+++ b/docs/cli/cello_sync.md
@@ -1,14 +1,15 @@
-## argo-cloudops diff
-Diff a project target using a manifest in git
+## cello sync
+
+Syncs a project target using a manifest in git
 
 ```
-  argo-cloudops diff [flags]
+  cello sync [flags]
 ```
 
 ### Flags
 
 ```
-  -h, --help                  help for diff
+  -h, --help                  help for sync
   -p, --path string           Path to manifest within git repository
   -n, --project_name string   Name of project
   -s, --sha string            Commit sha to use when creating workflow through git

--- a/docs/cli/cello_workflow.md
+++ b/docs/cli/cello_workflow.md
@@ -1,8 +1,8 @@
-## argo-cloudops workflow
+## cello workflow
 Creates a workflow execution with provided arguments
 
 ```
-  argo-cloudops workflow [flags]
+  cello workflow [flags]
 ```
 
 ### Flags

--- a/docs/developers/api.md
+++ b/docs/developers/api.md
@@ -109,7 +109,7 @@ Response Body
       "arn:aws:iam::aws:policy/AWSCloudFormationFullAccess"
     ],
     "policy_document": "{ \"Version\": \"2012-10-17\", \"Statement\": [ { \"Effect\": \"Allow\", \"Action\": \"s3:ListBuckets\", \"Resource\": \"*\" } ] }",
-    "role_arn": "arn:aws:iam::123456789012:role/ArgoCloudOpsSampleRole"
+    "role_arn": "arn:aws:iam::123456789012:role/CelloSampleRole"
   }
 }
 ```
@@ -154,7 +154,7 @@ Response Body
       "arn:aws:iam::aws:policy/AWSCloudFormationFullAccess"
     ],
     "policy_document": "{ \"Version\": \"2012-10-17\", \"Statement\": [ { \"Effect\": \"Allow\", \"Action\": \"s3:ListBuckets\", \"Resource\": \"*\" } ] }",
-    "role_arn": "arn:aws:iam::123456789012:role/ArgoCloudOpsSampleRole"
+    "role_arn": "arn:aws:iam::123456789012:role/CelloSampleRole"
   }
 }
 ```
@@ -188,7 +188,7 @@ Request Body
   },
   "environment_variables": {
     "AWS_REGION": "us-west-2",
-    "CODE_URI": "s3://argo-cloudops-cet-dev/terraform-example.zip",
+    "CODE_URI": "s3://cello-cet-dev/terraform-example.zip",
     "VAULT_ADDR": "http://docker.for.mac.localhost:8200"
   },
   "framework": "terraform",

--- a/docs/developers/development-env.md
+++ b/docs/developers/development-env.md
@@ -120,8 +120,8 @@ You will need two windows
   CDK_WORKFLOW_NAME=`bash scripts/run_gitops_example.sh manifests/cdk_manifest.yaml e3a419e69a5ae762862dc7cf382304a4e6cc2547 dev`
 
   # Get the status / logs
-  ./build/argo-cloudops get $CDK_WORKFLOW_NAME
-  ./build/argo-cloudops logs $CDK_WORKFLOW_NAME
+  ./build/cello get $CDK_WORKFLOW_NAME
+  ./build/cello logs $CDK_WORKFLOW_NAME
   ```
 
 - TERRAFORM Example
@@ -131,7 +131,7 @@ You will need two windows
   TERRAFORM_WORKFLOW_NAME=`bash scripts/run_gitops_example.sh manifests/terraform_manifest.yaml e3a419e69a5ae762862dc7cf382304a4e6cc2547 dev`
 
   # Get the status / logs
-  ./build/argo-cloudops get $TERRAFORM_WORKFLOW_NAME
-  ./build/argo-cloudops logs $TERRAFORM_WORKFLOW_NAME
+  ./build/cello get $TERRAFORM_WORKFLOW_NAME
+  ./build/cello logs $TERRAFORM_WORKFLOW_NAME
   ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -70,8 +70,8 @@ You will need two windows
   CDK_WORKFLOW_NAME=`bash scripts/run_gitops_example.sh manifests/kube_cdk_manifest.yaml e3a419e69a5ae762862dc7cf382304a4e6cc2547`
 
   # Get the status/follow the logs
-  ./quickstart/argo-cloudops get $CDK_WORKFLOW_NAME
-  ./quickstart/argo-cloudops logs -f $CDK_WORKFLOW_NAME
+  ./quickstart/cello get $CDK_WORKFLOW_NAME
+  ./quickstart/cello logs -f $CDK_WORKFLOW_NAME
   ```
 
 - TERRAFORM Example
@@ -81,6 +81,6 @@ You will need two windows
   TERRAFORM_WORKFLOW_NAME=`bash scripts/run_gitops_example.sh manifests/kube_terraform_manifest.yaml e3a419e69a5ae762862dc7cf382304a4e6cc2547`
 
   # Get the status/follow the logs
-  ./quickstart/argo-cloudops get $TERRAFORM_WORKFLOW_NAME
-  ./quickstart/argo-cloudops logs -f $TERRAFORM_WORKFLOW_NAME
+  ./quickstart/cello get $TERRAFORM_WORKFLOW_NAME
+  ./quickstart/cello logs -f $TERRAFORM_WORKFLOW_NAME
   ```

--- a/docs/users/cli.md
+++ b/docs/users/cli.md
@@ -3,18 +3,18 @@
 The CLI allows to (amongst other things) manage projects, sync, watch, and list deployments, e.g.: 
 
 ```sh
-WFNAME=`argo-cloudops sync -n project1 -t target1 -p git_path -s git_sha`
-argo-cloudops logs $WFNAME -f    
+WFNAME=`cello sync -n project1 -t target1 -p git_path -s git_sha`
+cello logs $WFNAME -f    
 ```   
 
 ## Reference
 
-You can find [detailed reference here](/cli/argo-cloudops)
+You can find [detailed reference here](/cli/cello)
 
 ## Help
 
 Most help topics are provided by built-in help:
 
 ```
-argo-cloudops --help
+cello --help
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,13 +25,13 @@ nav:
       - Environment Variables: users/envvars.md
       - Examples: https://github.com/cello-proj/cello/blob/master/examples/README.md
       - CLI Reference:
-          - argo-cloudops: cli/argo-cloudops.md
-          - argo-cloudops sync: cli/argo-cloudops_sync.md
-          - argo-cloudops diff: cli/argo-cloudops_diff.md
-          - argo-cloudops get: cli/argo-cloudops_get.md
-          - argo-cloudops list: cli/argo-cloudops_list.md
-          - argo-cloudops workflow: cli/argo-cloudops_workflow.md
-          - argo-cloudops logs: cli/argo-cloudops_logs.md
+          - cello: cli/cello.md
+          - cello sync: cli/cello_sync.md
+          - cello diff: cli/cello_diff.md
+          - cello get: cli/cello_get.md
+          - cello list: cli/cello_list.md
+          - cello workflow: cli/cello_workflow.md
+          - cello logs: cli/cello_logs.md
   - Developer Guide:
       - Local Development Environment: developers/development-env.md
       - Contributing: developers/CONTRIBUTING.md

--- a/scripts/quickstart_manifest.yaml
+++ b/scripts/quickstart_manifest.yaml
@@ -665,7 +665,7 @@ spec:
   selector:
    app: postgres
 
-# ARGO CLOUDOPS
+# CELLO
 
 ---
 apiVersion: apps/v1

--- a/scripts/quickstart_run.sh
+++ b/scripts/quickstart_run.sh
@@ -61,7 +61,7 @@ latest_release=$(curl --silent "https://api.github.com/repos/cello-proj/cello/re
 latest_release="${latest_release//v}"
 
 # download Cello CLI if it doesn't exist
-if [ ! -f quickstart/argo-cloudops ]; then
+if [ ! -f quickstart/cello ]; then
     curl -L https://github.com/cello-proj/cello/releases/download/v${latest_release}/cello_cli_${latest_release}_darwin_x86_64.tar.gz -o quickstart/cello_cli_${latest_release}_darwin_x86_64.tar.gz &> /dev/null
       tar -xzf quickstart/cello_cli_${latest_release}_darwin_x86_64.tar.gz -C quickstart/ #&> /dev/null
         rm quickstart/cello_cli_${latest_release}_darwin_x86_64.tar.gz &> /dev/null

--- a/scripts/run_gitops_example.sh
+++ b/scripts/run_gitops_example.sh
@@ -19,9 +19,9 @@ fi
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 if [ "${MODE}" == "dev" ]; then
-  CLI=$SCRIPT_DIR/../build/argo-cloudops
+  CLI=$SCRIPT_DIR/../build/cello
 else
-  CLI=$SCRIPT_DIR/../quickstart/argo-cloudops
+  CLI=$SCRIPT_DIR/../quickstart/cello
 fi
 
 $CLI exec \


### PR DESCRIPTION
CLI binary has been renamed from argo-cloudops to cello as well as docs referencing the binary commands