### PR TITLE
feat: env prefix migrated to CELLO with legacy fallback

### DIFF
--- a/service/internal/env/env_test.go
+++ b/service/internal/env/env_test.go
@@ -11,101 +11,104 @@ import (
 // #nosec
 const testSecret = "tha5hei2Hee5le8n"
 
-var allEnvVars = []string{
-	"ARGO_CLOUDOPS_ADMIN_SECRET",
-	"VAULT_ROLE",
-	"VAULT_SECRET",
-	"VAULT_ADDR",
-	"ARGO_ADDR",
-	"ARGO_CLOUDOPS_WORKFLOW_EXECUTION_NAMESPACE",
-	"ARGO_CLOUDOPS_CONFIG",
-	"ARGO_CLOUDOPS_GIT_AUTH_METHOD",
-	"SSH_PEM_FILE",
-	"ARGO_CLOUDOPS_GIT_HTTPS_USER",
-	"ARGO_CLOUDOPS_GIT_HTTPS_PASS",
-	"ARGO_CLOUDOPS_LOG_LEVEL",
-	"ARGO_CLOUDOPS_PORT",
+var prefixedEnvVars = map[string]string{
+	"_ADMIN_SECRET":                 testSecret,
+	"_WORKFLOW_EXECUTION_NAMESPACE": "argo-ns",
+	"_CONFIG":                       "/app/test/config/path",
+	"_GIT_AUTH_METHOD":              "https",
+	"_GIT_HTTPS_USER":               "testuser",
+	"_GIT_HTTPS_PASS":               "testpass",
+	"_LOG_LEVEL":                    "DEBUG",
+	"_PORT":                         "1234",
+	"_DB_HOST":                      "localhost",
+	"_DB_NAME":                      "argocloudops",
+	"_DB_USER":                      "argoco",
+	"_DB_PASSWORD":                  "1234",
 }
 
-func setup() {
-	for _, envVar := range allEnvVars {
-		os.Unsetenv(envVar)
+var nonPrefixedEnvVars = map[string]string{
+	"VAULT_ROLE":   "vaultRole",
+	"VAULT_SECRET": testSecret,
+	"VAULT_ADDR":   "1.2.3.4",
+	"ARGO_ADDR":    "2.3.4.5",
+	"SSH_PEM_FILE": "/app/test/ssh.pem",
+}
+
+func reset() {
+	for k := range prefixedEnvVars {
+		os.Unsetenv(appPrefix + k)
 	}
+	for k := range nonPrefixedEnvVars {
+		os.Unsetenv(k)
+	}
+
 	instance = Vars{}
 	once = sync.Once{}
 }
 
+func setEnvVars(vars map[string]string, prefix string) {
+	for k, v := range vars {
+		os.Setenv(prefix+k, v)
+	}
+}
+
 func TestGetEnv(t *testing.T) {
 	// Given
-	setup()
-	os.Setenv("ARGO_CLOUDOPS_ADMIN_SECRET", testSecret)
-	os.Setenv("VAULT_ROLE", "vaultRole")
-	os.Setenv("VAULT_SECRET", testSecret)
-	os.Setenv("VAULT_ADDR", "1.2.3.4")
-	os.Setenv("ARGO_ADDR", "2.3.4.5")
-	os.Setenv("ARGO_CLOUDOPS_WORKFLOW_EXECUTION_NAMESPACE", "argo-ns")
-	os.Setenv("ARGO_CLOUDOPS_CONFIG", "/app/test/config/path")
-	os.Setenv("SSH_PEM_FILE", "/app/test/ssh.pem")
-	os.Setenv("ARGO_CLOUDOPS_GIT_AUTH_METHOD", "https")
-	os.Setenv("ARGO_CLOUDOPS_GIT_HTTPS_USER", "testuser")
-	os.Setenv("ARGO_CLOUDOPS_GIT_HTTPS_PASS", "testpass")
-	os.Setenv("ARGO_CLOUDOPS_DB_HOST", "localhost")
-	os.Setenv("ARGO_CLOUDOPS_DB_NAME", "argocloudops")
-	os.Setenv("ARGO_CLOUDOPS_DB_USER", "argoco")
-	os.Setenv("ARGO_CLOUDOPS_DB_PASSWORD", "1234")
-	os.Setenv("ARGO_CLOUDOPS_LOG_LEVEL", "DEBUG")
-	os.Setenv("ARGO_CLOUDOPS_PORT", "1234")
+	reset()
+	setEnvVars(prefixedEnvVars, appPrefix)
+	setEnvVars(nonPrefixedEnvVars, "")
 
 	// When
-	var env, _ = GetEnv()
+	vars, err := GetEnv()
 
 	// Then
-	assert.Equal(t, env.AdminSecret, testSecret)
-	assert.Equal(t, env.VaultRole, "vaultRole")
-	assert.Equal(t, env.VaultSecret, testSecret)
-	assert.Equal(t, env.VaultAddress, "1.2.3.4")
-	assert.Equal(t, env.ArgoNamespace, "argo-ns")
-	assert.Equal(t, env.ConfigFilePath, "/app/test/config/path")
-	assert.Equal(t, env.SSHPEMFile, "/app/test/ssh.pem")
-	assert.Equal(t, env.GitAuthMethod, "https")
-	assert.Equal(t, env.GitHTTPSUser, "testuser")
-	assert.Equal(t, env.GitHTTPSPass, "testpass")
-	assert.Equal(t, env.LogLevel, "DEBUG")
-	assert.Equal(t, env.Port, 1234)
-	assert.Equal(t, env.DBHost, "localhost")
-	assert.Equal(t, env.DBName, "argocloudops")
-	assert.Equal(t, env.DBUser, "argoco")
-	assert.Equal(t, env.DBPassword, "1234")
+	assert.NoError(t, err)
+	assert.Equal(t, testSecret, vars.AdminSecret)
+	assert.Equal(t, "vaultRole", vars.VaultRole)
+	assert.Equal(t, testSecret, vars.VaultSecret)
+	assert.Equal(t, "1.2.3.4", vars.VaultAddress)
+	assert.Equal(t, "argo-ns", vars.ArgoNamespace)
+	assert.Equal(t, "/app/test/config/path", vars.ConfigFilePath)
+	assert.Equal(t, "/app/test/ssh.pem", vars.SSHPEMFile)
+	assert.Equal(t, "https", vars.GitAuthMethod)
+	assert.Equal(t, "testuser", vars.GitHTTPSUser)
+	assert.Equal(t, "testpass", vars.GitHTTPSPass)
+	assert.Equal(t, "DEBUG", vars.LogLevel)
+	assert.Equal(t, 1234, vars.Port)
+	assert.Equal(t, "localhost", vars.DBHost)
+	assert.Equal(t, "argocloudops", vars.DBName)
+	assert.Equal(t, "argoco", vars.DBUser)
+	assert.Equal(t, "1234", vars.DBPassword)
 }
 
 func TestDefaults(t *testing.T) {
 	// Given
-	setup()
-	os.Setenv("ARGO_CLOUDOPS_ADMIN_SECRET", testSecret)
+	reset()
+	os.Setenv(appPrefix+"_ADMIN_SECRET", testSecret)
 	os.Setenv("VAULT_ROLE", "vaultRole")
 	os.Setenv("VAULT_SECRET", testSecret)
 	os.Setenv("VAULT_ADDR", "1.2.3.4")
 	os.Setenv("ARGO_ADDR", "2.3.4.5")
-	os.Setenv("ARGO_CLOUDOPS_GIT_AUTH_METHOD", "https")
+	os.Setenv(appPrefix+"_GIT_AUTH_METHOD", "https")
 
 	// When
-	var env, _ = GetEnv()
+	vars, _ := GetEnv()
 
 	// Then
-	assert.Equal(t, env.ArgoNamespace, "argo")
-	assert.Equal(t, env.ConfigFilePath, "argo-cloudops.yaml")
-	assert.Equal(t, env.Port, 8443)
+	assert.Equal(t, "argo", vars.ArgoNamespace)
+	assert.Equal(t, "argo-cloudops.yaml", vars.ConfigFilePath)
+	assert.Equal(t, 8443, vars.Port)
 }
 
 func TestValidations(t *testing.T) {
 	// Given
-	setup()
-	os.Setenv("ARGO_CLOUDOPS_ADMIN_SECRET", "PW1234")
+	reset()
+	os.Setenv(appPrefix+"_ADMIN_SECRET", "PW1234")
 	os.Setenv("VAULT_ROLE", "vaultRole")
 	os.Setenv("VAULT_SECRET", testSecret)
 	os.Setenv("VAULT_ADDR", "1.2.3.4")
 	os.Setenv("ARGO_ADDR", "2.3.4.5")
-	os.Setenv("ARGO_CLOUDOPS_GIT_AUTH_METHOD", "https")
+	os.Setenv(appPrefix+"_GIT_AUTH_METHOD", "https")
 
 	// When
 	_, err := GetEnv()
@@ -116,20 +119,40 @@ func TestValidations(t *testing.T) {
 
 func TestRequiredVars(t *testing.T) {
 	// Given
-	setup()
+	reset()
 	os.Setenv("VAULT_ROLE", "vaultRole")
 	os.Setenv("VAULT_SECRET", testSecret)
 	os.Setenv("VAULT_ADDR", "1.2.3.4")
 	os.Setenv("ARGO_ADDR", "2.3.4.5")
-	os.Setenv("ARGO_CLOUDOPS_NAMESPACE", "argo-ns")
-	os.Setenv("ARGO_CLOUDOPS_CONFIG", "/app/test/config/path")
-	os.Setenv("ARGO_CLOUDOPS_GIT_AUTH_METHOD", "https")
-	os.Setenv("ARGO_CLOUDOPS_LOG_LEVEL", "DEBUG")
-	os.Setenv("ARGO_CLOUDOPS_PORT", "1234")
+	os.Setenv(appPrefix+"_NAMESPACE", "argo-ns")
+	os.Setenv(appPrefix+"_CONFIG", "/app/test/config/path")
+	os.Setenv(appPrefix+"_GIT_AUTH_METHOD", "https")
+	os.Setenv(appPrefix+"_LOG_LEVEL", "DEBUG")
+	os.Setenv(appPrefix+"_PORT", "1234")
 
 	// When
 	_, err := GetEnv()
 
 	// Then
 	assert.Error(t, err)
+}
+
+func TestMigrateLegacyPrefix(t *testing.T) {
+	reset()
+	// Required vars with legacy prefixes
+	setEnvVars(prefixedEnvVars, legacyAppPrefix)
+	setEnvVars(nonPrefixedEnvVars, "")
+
+	vars, err := GetEnv()
+	assert.Equal(t, 0, vars.Port) // unsuccessfully set
+	assert.Error(t, err)
+
+	reset() // because this is forced to a singleton
+	setEnvVars(nonPrefixedEnvVars, "")
+	migrateLegacyPrefix()
+
+	vars, err = GetEnv()
+	assert.NoError(t, err)
+	assert.Equal(t, 1234, vars.Port)
+
 }


### PR DESCRIPTION
Identifies the ARGO_CLOUDOPS env var prefix as legacy in code, migrates on init, and refactors env tests to: correctly order expected and actual assertions, clarity in naming changes, and coverage for the prefix migration step.