### PR TITLE
feat: insert token to DB on project create

### DIFF
--- a/service/handlers.go
+++ b/service/handlers.go
@@ -602,6 +602,15 @@ func (h handler) createProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	level.Debug(l).Log("message", "inserting token into DB")
+	te, err := h.dbClient.CreateTokenEntry(ctx, capp.Name, secretAccessor)
+	if err != nil {
+		level.Error(l).Log("message", "error inserting token into DB", "error", err)
+		h.errorResponse(w, "error creating token", http.StatusInternalServerError)
+		return
+	}
+	fmt.Println("TOKEN::", te)
+
 	level.Debug(l).Log("message", "retrieving Cello token")
 	token := newCelloToken("vault", role, secret)
 

--- a/service/handlers_test.go
+++ b/service/handlers_test.go
@@ -52,7 +52,7 @@ func (d mockDB) CreateProjectEntry(ctx context.Context, pe db.ProjectEntry) erro
 }
 
 func (d mockDB) CreateTokenEntry(ctx context.Context, project string, secretAccessor string) (db.TokenEntry, error) {
-	if project == "tokendberror" {
+	if project == "tokendberror" || project == "tokendbentryerror" {
 		return db.TokenEntry{}, fmt.Errorf("token db error")
 	}
 
@@ -305,6 +305,14 @@ func TestCreateProject(t *testing.T) {
 		{
 			name:       "project fails to create db entry",
 			req:        loadJSON(t, "TestCreateProject/project_fails_to_create_dbentry.json"),
+			want:       http.StatusInternalServerError,
+			authHeader: adminAuthHeader,
+			url:        "/projects",
+			method:     "POST",
+		},
+		{
+			name:       "project fails to create token entry",
+			req:        loadJSON(t, "TestCreateProject/project_fails_to_create_token_entry.json"),
 			want:       http.StatusInternalServerError,
 			authHeader: adminAuthHeader,
 			url:        "/projects",

--- a/service/test/testdata/TestCreateProject/project_fails_to_create_token_entry.json
+++ b/service/test/testdata/TestCreateProject/project_fails_to_create_token_entry.json
@@ -1,0 +1,4 @@
+{
+  "name": "tokendbentryerror",
+  "repository": "https://github.com/myorg/myrepo.git"
+}


### PR DESCRIPTION
On initial project creation, the token associated to the initial secret should be stored in the Tokens DB.