### PR TITLE
feat: limit number of tokens created

### DIFF
--- a/service/handlers.go
+++ b/service/handlers.go
@@ -602,6 +602,15 @@ func (h handler) createProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	level.Debug(l).Log("message", "inserting token into DB")
+	te, err := h.dbClient.CreateTokenEntry(ctx, capp.Name, secretAccessor)
+	if err != nil {
+		level.Error(l).Log("message", "error inserting token into DB", "error", err)
+		h.errorResponse(w, "error creating token", http.StatusInternalServerError)
+		return
+	}
+	fmt.Println("TOKEN::", te)
+
 	level.Debug(l).Log("message", "retrieving Cello token")
 	token := newCelloToken("vault", role, secret)
 

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -1138,6 +1138,12 @@ func (h handler) createToken(w http.ResponseWriter, r *http.Request) {
 	}
 
 	tokens, err := h.dbClient.ListTokenEntries(ctx, projectName)
+	if err != nil {
+		level.Error(l).Log("message", "error listing tokens from DB", "error", err)
+		h.errorResponse(w, "error listing tokens", http.StatusInternalServerError)
+		return
+	}
+
 	if len(tokens) == numOfTokensLimit {
 		level.Error(l).Log("message", "number of tokens allowed per project has been reached")
 		h.errorResponse(w, "token limit reached", http.StatusInternalServerError)

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -1144,7 +1144,7 @@ func (h handler) createToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(tokens) == numOfTokensLimit {
+	if len(tokens) >= numOfTokensLimit {
 		level.Error(l).Log("message", "number of tokens allowed per project has been reached")
 		h.errorResponse(w, "token limit reached", http.StatusInternalServerError)
 		return

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -25,6 +25,10 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const (
+	numOfTokensLimit = 2
+)
+
 // Represents a JWT token.
 type token struct {
 	Token string `json:"token"`
@@ -1131,6 +1135,13 @@ func (h handler) createToken(w http.ResponseWriter, r *http.Request) {
 	projectExists, err := h.projectExists(ctx, l, cp, w, projectName)
 
 	if err != nil || !projectExists {
+		return
+	}
+
+	tokens, err := h.dbClient.ListTokenEntries(ctx, projectName)
+	if len(tokens) == numOfTokensLimit {
+		level.Error(l).Log("message", "number of tokens allowed per project has been reached")
+		h.errorResponse(w, "token limit reached", http.StatusInternalServerError)
 		return
 	}
 

--- a/service/handlers_test.go
+++ b/service/handlers_test.go
@@ -52,7 +52,7 @@ func (d mockDB) CreateProjectEntry(ctx context.Context, pe db.ProjectEntry) erro
 }
 
 func (d mockDB) CreateTokenEntry(ctx context.Context, project string, secretAccessor string) (db.TokenEntry, error) {
-	if project == "tokendberror" {
+	if project == "tokendberror" || project == "tokendbentryerror" {
 		return db.TokenEntry{}, fmt.Errorf("token db error")
 	}
 
@@ -305,6 +305,14 @@ func TestCreateProject(t *testing.T) {
 		{
 			name:       "project fails to create db entry",
 			req:        loadJSON(t, "TestCreateProject/project_fails_to_create_dbentry.json"),
+			want:       http.StatusInternalServerError,
+			authHeader: adminAuthHeader,
+			url:        "/projects",
+			method:     "POST",
+		},
+		{
+			name:       "project fails to create token entry",
+			req:        loadJSON(t, "TestCreateProject/project_fails_to_create_token_entry.json"),
 			want:       http.StatusInternalServerError,
 			authHeader: adminAuthHeader,
 			url:        "/projects",

--- a/service/handlers_test.go
+++ b/service/handlers_test.go
@@ -81,7 +81,7 @@ func (d mockDB) ListTokenEntries(ctx context.Context, project string) ([]db.Toke
 		return []db.TokenEntry{{ProjectID: "project1", TokenID: "1234"}, {ProjectID: "project1", TokenID: "5678"}}, nil
 	}
 
-	return []db.TokenEntry{}, upper.ErrNoMoreRows
+	return []db.TokenEntry{}, nil
 }
 
 func (d mockDB) ReadProjectEntry(ctx context.Context, project string) (db.ProjectEntry, error) {
@@ -372,6 +372,15 @@ func TestCreateToken(t *testing.T) {
 			respFile:   "TestCreateToken/token_limit_reached_response.json",
 			authHeader: adminAuthHeader,
 			url:        "/projects/projectlisttokenslimit/tokens",
+			method:     "POST",
+		},
+		{
+			name:       "error listing tokens",
+			req:        loadJSON(t, "TestCreateToken/request.json"),
+			want:       http.StatusInternalServerError,
+			respFile:   "TestCreateToken/error_listing_tokens_response.json",
+			authHeader: adminAuthHeader,
+			url:        "/projects/projectlisttokenserror/tokens",
 			method:     "POST",
 		},
 	}

--- a/service/test/testdata/TestCreateProject/project_fails_to_create_token_entry.json
+++ b/service/test/testdata/TestCreateProject/project_fails_to_create_token_entry.json
@@ -1,0 +1,4 @@
+{
+  "name": "tokendbentryerror",
+  "repository": "https://github.com/myorg/myrepo.git"
+}

--- a/service/test/testdata/TestCreateToken/error_listing_tokens_response.json
+++ b/service/test/testdata/TestCreateToken/error_listing_tokens_response.json
@@ -1,0 +1,3 @@
+{
+  "error_message": "error listing tokens"
+}

--- a/service/test/testdata/TestCreateToken/token_limit_reached_response.json
+++ b/service/test/testdata/TestCreateToken/token_limit_reached_response.json
@@ -1,0 +1,3 @@
+{
+  "error_message": "token limit reached"
+}


### PR DESCRIPTION
Limiting the number of tokens created to 2 tokens. This should eventually be configurable in the future.