### PR TITLE
Optimize listWorkflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+* Listing workflows no longer calls a status for each workflow
+
 ## [0.14.1] - 2022-07-14
 ### Added
 * Expiration time for token

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -106,7 +106,7 @@ func (h handler) listWorkflows(w http.ResponseWriter, r *http.Request) {
 	l := h.requestLogger(r, "op", "list-workflows", "project", projectName, "target", targetName)
 
 	level.Debug(l).Log("message", "listing workflows")
-	workflowList, err := h.argo.List(h.argoCtx)
+	workflowList, err := h.argo.ListStatus(h.argoCtx)
 	if err != nil {
 		level.Error(l).Log("message", "error listing workflows", "error", err)
 		h.errorResponse(w, "error listing workflows", http.StatusInternalServerError)

--- a/service/handlers_test.go
+++ b/service/handlers_test.go
@@ -931,7 +931,7 @@ func TestListWorkflows(t *testing.T) {
 			method:     "GET",
 			url:        "/projects/projects1/targets/target1/workflows",
 			wfMock: &th.WorkflowMock{
-				ListFunc: func(ctx context.Context) ([]workflow.Status, error) {
+				ListStatusFunc: func(ctx context.Context) ([]workflow.Status, error) {
 					return []workflow.Status{
 						{
 							Name:     "project1-target1-abcde",

--- a/service/handlers_test.go
+++ b/service/handlers_test.go
@@ -155,7 +155,6 @@ func TestCreateProject(t *testing.T) {
 
 func TestCreateToken(t *testing.T) {
 	tests := []test{
-
 		{
 			name:       "can create token",
 			req:        loadJSON(t, "TestCreateToken/request.json"),
@@ -932,8 +931,21 @@ func TestListWorkflows(t *testing.T) {
 			method:     "GET",
 			url:        "/projects/projects1/targets/target1/workflows",
 			wfMock: &th.WorkflowMock{
-				ListFunc: func(ctx context.Context) ([]string, error) {
-					return []string{"project1-target1-abcde", "project2-target2-12345"}, nil
+				ListFunc: func(ctx context.Context) ([]workflow.Status, error) {
+					return []workflow.Status{
+						{
+							Name:     "project1-target1-abcde",
+							Status:   "succeeded",
+							Created:  "1658514800",
+							Finished: "1658514856",
+						},
+						{
+							Name:     "project2-target2-12345",
+							Status:   "succeeded",
+							Created:  "1658514764",
+							Finished: "1658514793",
+						},
+					}, nil
 				},
 			},
 		},
@@ -1332,7 +1344,7 @@ func runTests(t *testing.T, tests []test) {
 }
 
 func executeRequestWithHandler(h handler, method string, url string, body *bytes.Buffer, authHeader string) *http.Response {
-	var router = setupRouter(h)
+	router := setupRouter(h)
 	req, _ := http.NewRequest(method, url, body)
 
 	req.Header.Add("Authorization", authHeader)

--- a/service/internal/workflow/workflow.go
+++ b/service/internal/workflow/workflow.go
@@ -20,7 +20,7 @@ const mainContainer = "main"
 
 // Workflow interface is used for interacting with workflow services.
 type Workflow interface {
-	List(ctx context.Context) ([]string, error)
+	List(ctx context.Context) ([]Status, error)
 	Logs(ctx context.Context, workflowName string) (*Logs, error)
 	LogStream(ctx context.Context, workflowName string, data http.ResponseWriter) error
 	Status(ctx context.Context, workflowName string) (*Status, error)
@@ -47,22 +47,31 @@ type Logs struct {
 }
 
 // List returns a list of workflows.
-func (a ArgoWorkflow) List(ctx context.Context) ([]string, error) {
-	workflowIDs := []string{}
+func (a ArgoWorkflow) List(ctx context.Context) ([]Status, error) {
+	workflows := []Status{}
 
 	workflowListResult, err := a.svc.ListWorkflows(ctx, &argoWorkflowAPIClient.WorkflowListRequest{
 		Namespace: a.namespace,
 	})
-
 	if err != nil {
-		return workflowIDs, err
+		return workflows, err
 	}
 
-	for _, item := range workflowListResult.Items {
-		workflowIDs = append(workflowIDs, item.ObjectMeta.Name)
+	for _, wf := range workflowListResult.Items {
+		wfStatus := Status{
+			Name:    wf.ObjectMeta.Name,
+			Status:  strings.ToLower(string(wf.Status.Phase)),
+			Created: fmt.Sprint(wf.ObjectMeta.CreationTimestamp.Unix()),
+		}
+
+		if wf.Status.Phase != argoWorkflowAPISpec.WorkflowRunning {
+			wfStatus.Finished = fmt.Sprint(wf.Status.FinishedAt.Unix())
+		}
+
+		workflows = append(workflows, wfStatus)
 	}
 
-	return workflowIDs, nil
+	return workflows, nil
 }
 
 // Status represents a workflow status.
@@ -70,7 +79,7 @@ type Status struct {
 	Name     string `json:"name"`
 	Status   string `json:"status"`
 	Created  string `json:"created"`
-	Finished string `json:"finished"`
+	Finished string `json:"finished,omitempty"`
 }
 
 // Status returns a workflow status.
@@ -79,7 +88,6 @@ func (a ArgoWorkflow) Status(ctx context.Context, workflowName string) (*Status,
 		Name:      workflowName,
 		Namespace: a.namespace,
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +111,6 @@ func (a ArgoWorkflow) Logs(ctx context.Context, workflowName string) (*Logs, err
 			Container: mainContainer,
 		},
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +142,6 @@ func (a ArgoWorkflow) LogStream(ctx context.Context, workflowName string, w http
 			Follow:    true,
 		},
 	})
-
 	if err != nil {
 		return err
 	}
@@ -197,7 +203,6 @@ func (a ArgoWorkflow) Submit(ctx context.Context, from string, parameters map[st
 			Labels:       labels.FormatLabels(workflowLabels),
 		},
 	})
-
 	if err != nil {
 		return "", fmt.Errorf("failed to submit workflow: %w", err)
 	}

--- a/service/internal/workflow/workflow_test.go
+++ b/service/internal/workflow/workflow_test.go
@@ -51,7 +51,7 @@ func TestArgoWorkflowsList(t *testing.T) {
 				"namespace",
 			)
 
-			out, err := argoWf.List(context.Background())
+			out, err := argoWf.ListStatus(context.Background())
 			if err != nil {
 				if tt.errResult != nil && tt.errResult.Error() != err.Error() {
 					t.Errorf("\nwant: %v\n got: %v", tt.errResult, err)

--- a/service/internal/workflow/workflow_test.go
+++ b/service/internal/workflow/workflow_test.go
@@ -15,18 +15,30 @@ import (
 func TestArgoWorkflowsList(t *testing.T) {
 	tests := []struct {
 		name      string
-		output    []string
+		output    []Status
 		listErr   error
 		errResult error
 	}{
 		{
-			name:      "list workflows success",
-			output:    []string{"testWorkflow1"},
+			name: "list workflows success",
+			output: []Status{
+				{
+					Name:    "testWorkflow1",
+					Status:  "running",
+					Created: "1658514000",
+				},
+				{
+					Name:     "testWorkflow2",
+					Status:   "succeeded",
+					Created:  "1658512485",
+					Finished: "1658512623",
+				},
+			},
 			errResult: nil,
 		},
 		{
 			name:      "list workflows error",
-			output:    []string{},
+			output:    []Status{},
 			listErr:   fmt.Errorf("list error"),
 			errResult: fmt.Errorf("list error"),
 		},
@@ -40,7 +52,6 @@ func TestArgoWorkflowsList(t *testing.T) {
 			)
 
 			out, err := argoWf.List(context.Background())
-
 			if err != nil {
 				if tt.errResult != nil && tt.errResult.Error() != err.Error() {
 					t.Errorf("\nwant: %v\n got: %v", tt.errResult, err)
@@ -175,7 +186,28 @@ func (m mockArgoClient) ListWorkflows(ctx context.Context, in *argoWorkflowAPICl
 		return nil, m.err
 	}
 	return &v1alpha1.WorkflowList{Items: []v1alpha1.Workflow{
-		{TypeMeta: v1.TypeMeta{}, ObjectMeta: v1.ObjectMeta{Name: "testWorkflow1"}}}}, nil
+		{
+			TypeMeta: v1.TypeMeta{},
+			ObjectMeta: v1.ObjectMeta{
+				Name:              "testWorkflow1",
+				CreationTimestamp: v1.Unix(1658514000, 0),
+			},
+			Status: v1alpha1.WorkflowStatus{
+				Phase: v1alpha1.WorkflowRunning,
+			},
+		},
+		{
+			TypeMeta: v1.TypeMeta{},
+			ObjectMeta: v1.ObjectMeta{
+				Name:              "testWorkflow2",
+				CreationTimestamp: v1.Unix(1658512485, 0),
+			},
+			Status: v1alpha1.WorkflowStatus{
+				Phase:      v1alpha1.WorkflowSucceeded,
+				FinishedAt: v1.Unix(1658512623, 0),
+			},
+		},
+	}}, nil
 }
 
 func (m mockArgoClient) GetWorkflow(ctx context.Context, in *argoWorkflowAPIClient.WorkflowGetRequest, opts ...grpc.CallOption) (*v1alpha1.Workflow, error) {

--- a/service/test/testhelpers/workflowMock.go
+++ b/service/test/testhelpers/workflowMock.go
@@ -20,8 +20,8 @@ var _ workflow.Workflow = &WorkflowMock{}
 //
 // 		// make and configure a mocked workflow.Workflow
 // 		mockedWorkflow := &WorkflowMock{
-// 			ListFunc: func(ctx context.Context) ([]workflow.Status, error) {
-// 				panic("mock out the List method")
+// 			ListStatusFunc: func(ctx context.Context) ([]workflow.Status, error) {
+// 				panic("mock out the ListStatus method")
 // 			},
 // 			LogStreamFunc: func(ctx context.Context, workflowName string, data http.ResponseWriter) error {
 // 				panic("mock out the LogStream method")
@@ -42,8 +42,8 @@ var _ workflow.Workflow = &WorkflowMock{}
 //
 // 	}
 type WorkflowMock struct {
-	// ListFunc mocks the List method.
-	ListFunc func(ctx context.Context) ([]workflow.Status, error)
+	// ListStatusFunc mocks the ListStatus method.
+	ListStatusFunc func(ctx context.Context) ([]workflow.Status, error)
 
 	// LogStreamFunc mocks the LogStream method.
 	LogStreamFunc func(ctx context.Context, workflowName string, data http.ResponseWriter) error
@@ -59,8 +59,8 @@ type WorkflowMock struct {
 
 	// calls tracks calls to the methods.
 	calls struct {
-		// List holds details about calls to the List method.
-		List []struct {
+		// ListStatus holds details about calls to the ListStatus method.
+		ListStatus []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 		}
@@ -99,41 +99,41 @@ type WorkflowMock struct {
 			Labels map[string]string
 		}
 	}
-	lockList      sync.RWMutex
-	lockLogStream sync.RWMutex
-	lockLogs      sync.RWMutex
-	lockStatus    sync.RWMutex
-	lockSubmit    sync.RWMutex
+	lockListStatus sync.RWMutex
+	lockLogStream  sync.RWMutex
+	lockLogs       sync.RWMutex
+	lockStatus     sync.RWMutex
+	lockSubmit     sync.RWMutex
 }
 
-// List calls ListFunc.
-func (mock *WorkflowMock) List(ctx context.Context) ([]workflow.Status, error) {
-	if mock.ListFunc == nil {
-		panic("WorkflowMock.ListFunc: method is nil but Workflow.List was just called")
+// ListStatus calls ListStatusFunc.
+func (mock *WorkflowMock) ListStatus(ctx context.Context) ([]workflow.Status, error) {
+	if mock.ListStatusFunc == nil {
+		panic("WorkflowMock.ListStatusFunc: method is nil but Workflow.ListStatus was just called")
 	}
 	callInfo := struct {
 		Ctx context.Context
 	}{
 		Ctx: ctx,
 	}
-	mock.lockList.Lock()
-	mock.calls.List = append(mock.calls.List, callInfo)
-	mock.lockList.Unlock()
-	return mock.ListFunc(ctx)
+	mock.lockListStatus.Lock()
+	mock.calls.ListStatus = append(mock.calls.ListStatus, callInfo)
+	mock.lockListStatus.Unlock()
+	return mock.ListStatusFunc(ctx)
 }
 
-// ListCalls gets all the calls that were made to List.
+// ListStatusCalls gets all the calls that were made to ListStatus.
 // Check the length with:
-//     len(mockedWorkflow.ListCalls())
-func (mock *WorkflowMock) ListCalls() []struct {
+//     len(mockedWorkflow.ListStatusCalls())
+func (mock *WorkflowMock) ListStatusCalls() []struct {
 	Ctx context.Context
 } {
 	var calls []struct {
 		Ctx context.Context
 	}
-	mock.lockList.RLock()
-	calls = mock.calls.List
-	mock.lockList.RUnlock()
+	mock.lockListStatus.RLock()
+	calls = mock.calls.ListStatus
+	mock.lockListStatus.RUnlock()
 	return calls
 }
 

--- a/service/test/testhelpers/workflowMock.go
+++ b/service/test/testhelpers/workflowMock.go
@@ -20,7 +20,7 @@ var _ workflow.Workflow = &WorkflowMock{}
 //
 // 		// make and configure a mocked workflow.Workflow
 // 		mockedWorkflow := &WorkflowMock{
-// 			ListFunc: func(ctx context.Context) ([]string, error) {
+// 			ListFunc: func(ctx context.Context) ([]workflow.Status, error) {
 // 				panic("mock out the List method")
 // 			},
 // 			LogStreamFunc: func(ctx context.Context, workflowName string, data http.ResponseWriter) error {
@@ -43,7 +43,7 @@ var _ workflow.Workflow = &WorkflowMock{}
 // 	}
 type WorkflowMock struct {
 	// ListFunc mocks the List method.
-	ListFunc func(ctx context.Context) ([]string, error)
+	ListFunc func(ctx context.Context) ([]workflow.Status, error)
 
 	// LogStreamFunc mocks the LogStream method.
 	LogStreamFunc func(ctx context.Context, workflowName string, data http.ResponseWriter) error
@@ -107,7 +107,7 @@ type WorkflowMock struct {
 }
 
 // List calls ListFunc.
-func (mock *WorkflowMock) List(ctx context.Context) ([]string, error) {
+func (mock *WorkflowMock) List(ctx context.Context) ([]workflow.Status, error) {
 	if mock.ListFunc == nil {
 		panic("WorkflowMock.ListFunc: method is nil but Workflow.List was just called")
 	}


### PR DESCRIPTION
I've been seeing the Get Workflows/listWorkflows endpoint return with long response times (~20s with ~4300 workflows). Argo Workflow lib method, [ListWorkflows](https://pkg.go.dev/github.com/argoproj/argo-workflows/v3@v3.3.8/pkg/apiclient/workflow#WorkflowServiceClient), essentially returns the same data as [GetWorkflow](https://pkg.go.dev/github.com/argoproj/argo-workflows/v3@v3.3.8/pkg/apiclient/workflow#WorkflowServiceClient), making the [GetWorkflow/Argo Workflow Status](https://github.com/cello-proj/cello/blob/main/service/handlers.go#L121) call redundant and unnecessarily causing the long response times for the endpoint. Given that ListWorkflows takes ~9s, this change should cut the response time in half.