### PR TITLE
fix: return an empty array for List workflows for targets with no workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+* List workflows returns an empty array instead of null for targets with no workflows
+
 ## [0.14.2] - 2022-07-28
 ### Changed
 * Listing workflows no longer calls a status for each workflow

--- a/go.mod
+++ b/go.mod
@@ -123,6 +123,7 @@ require (
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.1.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.0 // indirect

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -114,7 +114,7 @@ func (h handler) listWorkflows(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Only return workflows the target project / target
-	var workflows []workflow.Status
+	workflows := make([]workflow.Status, 0)
 	prefix := fmt.Sprintf("%s-%s", projectName, targetName)
 	for _, wf := range workflowList {
 		if strings.HasPrefix(wf.Name, prefix) {

--- a/service/handlers_test.go
+++ b/service/handlers_test.go
@@ -949,6 +949,18 @@ func TestListWorkflows(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:       "no workflows",
+			want:       http.StatusOK,
+			authHeader: userAuthHeader,
+			method:     "GET",
+			url:        "/projects/projects1/targets/target1/workflows",
+			wfMock: &th.WorkflowMock{
+				ListStatusFunc: func(ctx context.Context) ([]workflow.Status, error) {
+					return []workflow.Status{}, nil
+				},
+			},
+		},
 	}
 	runTests(t, tests)
 }


### PR DESCRIPTION
Currently, the return is a null for this case. The workflow unit tests were refactored as well, using argo-workflows' mocks based on mockery/testify.