### PR TITLE
fix: deprecate ioutil

### DIFF
--- a/cli/internal/api/api.go
+++ b/cli/internal/api/api.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -116,7 +115,7 @@ func (c *Client) streamLogsToWriterAtCursor(ctx context.Context, w io.Writer, wo
 	}
 
 	// discard reader bytes till cursor byte number
-	if _, err := io.CopyN(ioutil.Discard, resp.Body, *loggingCursorByte); err != nil {
+	if _, err := io.CopyN(io.Discard, resp.Body, *loggingCursorByte); err != nil {
 		return err
 	}
 	writtenBytes, err := io.Copy(w, resp.Body)

--- a/service/config.go
+++ b/service/config.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 	"text/template"
@@ -25,7 +25,7 @@ type Config struct {
 }
 
 func loadConfig(configFilePath string) (*Config, error) {
-	f, err := ioutil.ReadFile(configFilePath)
+	f, err := os.ReadFile(configFilePath)
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +96,6 @@ func generateExecuteCommand(commandDefinition, environmentVariablesString string
 	t, err := template.New("text").Parse(commandDefinition)
 	if err != nil {
 		return "", err
-
 	}
 	err = t.Execute(&buf, commandVariables)
 	if err != nil {

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -79,7 +79,7 @@ func (h *handler) healthCheck(w http.ResponseWriter, r *http.Request) {
 	// regardless.
 	// https://golang.org/pkg/net/http/#Client.Do
 	defer response.Body.Close()
-	_, err = ioutil.ReadAll(response.Body)
+	_, err = io.ReadAll(response.Body)
 	if err != nil {
 		level.Warn(l).Log("message", "unable to read vault body; continuing", "error", err)
 		// Continue on and handle the actual response code from Vault accordingly.
@@ -164,7 +164,7 @@ func (h handler) createWorkflowFromGit(w http.ResponseWriter, r *http.Request) {
 	}
 
 	level.Debug(l).Log("message", "reading request body")
-	reqBody, err := ioutil.ReadAll(r.Body)
+	reqBody, err := io.ReadAll(r.Body)
 	if err != nil {
 		level.Error(l).Log("message", "error reading request data", "error", err)
 		h.errorResponse(w, "error reading request data", http.StatusInternalServerError)
@@ -227,7 +227,7 @@ func (h handler) createWorkflow(w http.ResponseWriter, r *http.Request) {
 
 	level.Debug(l).Log("message", "reading request body")
 	var cwr requests.CreateWorkflow
-	reqBody, err := ioutil.ReadAll(r.Body)
+	reqBody, err := io.ReadAll(r.Body)
 	if err != nil {
 		level.Error(l).Log("message", "error reading workflow request data", "error", err)
 		h.errorResponse(w, "error reading workflow request data", http.StatusInternalServerError)
@@ -541,7 +541,7 @@ func (h handler) createProject(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	var capp requests.CreateProject
-	reqBody, err := ioutil.ReadAll(r.Body)
+	reqBody, err := io.ReadAll(r.Body)
 	if err != nil {
 		level.Error(l).Log("message", "error reading request body", "error", err)
 		h.errorResponse(w, "error reading request body", http.StatusInternalServerError)
@@ -759,7 +759,7 @@ func (h handler) createTarget(w http.ResponseWriter, r *http.Request) {
 	level.Debug(l).Log("message", "reading request body")
 
 	var ctr requests.CreateTarget
-	reqBody, err := ioutil.ReadAll(r.Body)
+	reqBody, err := io.ReadAll(r.Body)
 	if err != nil {
 		level.Error(l).Log("message", "error reading request data", "error", err)
 		h.errorResponse(w, "error reading request data", http.StatusInternalServerError)
@@ -978,7 +978,7 @@ func (h handler) updateTarget(w http.ResponseWriter, r *http.Request) {
 	targetType := target.Type
 
 	level.Debug(l).Log("message", "reading request body")
-	reqBody, err := ioutil.ReadAll(r.Body)
+	reqBody, err := io.ReadAll(r.Body)
 	if err != nil {
 		level.Error(l).Log("message", "error reading request data", "error", err)
 		h.errorResponse(w, "error reading request data", http.StatusInternalServerError)

--- a/service/handlers_test.go
+++ b/service/handlers_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1308,7 +1307,7 @@ func runTests(t *testing.T, tests []test) {
 			}
 
 			if tt.body != "" {
-				bodyBytes, err := ioutil.ReadAll(resp.Body)
+				bodyBytes, err := io.ReadAll(resp.Body)
 				defer resp.Body.Close()
 				if err != nil {
 					t.Errorf("Error loading body")

--- a/service/internal/git/gitClient.go
+++ b/service/internal/git/gitClient.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -101,7 +100,7 @@ func newBasicClient(auth transport.AuthMethod, opts ...Option) BasicClient {
 		git:     gitSvcImpl{},
 		fs:      os.DirFS(os.TempDir()),
 		baseDir: os.TempDir(),
-		pw:      ioutil.Discard,
+		pw:      io.Discard,
 	}
 
 	for _, o := range opts {


### PR DESCRIPTION
As of Go 1.16, `ioutil` has been deprecated. This was causing lint to error during builds.

https://go.dev/doc/go1.16#ioutil