### PR TITLE
fix(logs): remove workflow status call from cello log stream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	google.golang.org/genproto v0.0.0-20210917145530-b395a37504d4 // indirect
-	google.golang.org/grpc v1.41.0
+	google.golang.org/grpc v1.41.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.19.6


### PR DESCRIPTION
An EOF was being returned when streaming workflow logs on large outputs, and the stream was taking much longer than expected when compared to `argo logs` cli command. Looking into this deeper, Cello's implementation of log streaming made a Argo Workflow status call for each log line. This was the cause of log streaming not coming in fast enough. Theory is that the EOF was being returned because Cello was streaming a log that no longer existed in Argo Workflow.