### PR TITLE
[148] - Healthcheck endpoint returns application/json content type

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,5 @@ including CDK, Terraform and CloudFormation via GitOps.
 - [Architecture](/docs/architecture.md)
 - [API](/docs/developers/api.md)
 - [Development Setup](/docs/developers/development-env.md)
+
+

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -92,6 +92,7 @@ func (h *handler) healthCheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.Header().Set("Content-Type", "text/plain")
 	fmt.Fprintln(w, "Health check succeeded")
 }
 

--- a/service/handlers_test.go
+++ b/service/handlers_test.go
@@ -1222,18 +1222,21 @@ func TestHealthCheck(t *testing.T) {
 		writeBadContentLength bool // Used to create response body error.
 		wantResponseBody      string
 		wantStatusCode        int
+		wantResponseHeader    string
 	}{
 		{
-			name:             "good_vault_200",
-			vaultStatusCode:  http.StatusOK,
-			wantResponseBody: "Health check succeeded\n",
-			wantStatusCode:   http.StatusOK,
+			name:               "good_vault_200",
+			vaultStatusCode:    http.StatusOK,
+			wantResponseBody:   "Health check succeeded\n",
+			wantStatusCode:     http.StatusOK,
+			wantResponseHeader: "text/plain",
 		},
 		{
-			name:             "good_vault_429",
-			vaultStatusCode:  http.StatusTooManyRequests,
-			wantResponseBody: "Health check succeeded\n",
-			wantStatusCode:   http.StatusOK,
+			name:               "good_vault_429",
+			vaultStatusCode:    http.StatusTooManyRequests,
+			wantResponseBody:   "Health check succeeded\n",
+			wantStatusCode:     http.StatusOK,
+			wantResponseHeader: "text/plain",
 		},
 		{
 			// We want successful health check in this vault error scenario.
@@ -1242,6 +1245,7 @@ func TestHealthCheck(t *testing.T) {
 			writeBadContentLength: true,
 			wantResponseBody:      "Health check succeeded\n",
 			wantStatusCode:        http.StatusOK,
+			wantResponseHeader:    "text/plain",
 		},
 		{
 			name:             "error_vault_connection",
@@ -1309,6 +1313,7 @@ func TestHealthCheck(t *testing.T) {
 
 			assert.Equal(t, tt.wantStatusCode, respResult.StatusCode)
 			assert.Equal(t, tt.wantResponseBody, string(body))
+			assert.Equal(t, tt.wantResponseHeader, respResult.Header.Get("Content-Type"))
 		})
 	}
 }


### PR DESCRIPTION
This is a draft to attempt to change the content type of the Healthcheck endpoint for this application from `appliation/json` to `text/plain`.

I don't currently have access to an environment where I can test this change, that's hindering me from validating this change.