### PR TITLE
add type to workflow parameter

### DIFF
--- a/service/handlers.go
+++ b/service/handlers.go
@@ -337,7 +337,7 @@ func (h handler) createWorkflowFromRequest(_ context.Context, w http.ResponseWri
 	}
 
 	level.Debug(l).Log("message", "creating workflow parameters")
-	parameters := workflow.NewParameters(environmentVariablesString, executeCommand, executeContainerImageURI, cwr.TargetName, cwr.ProjectName, cwr.Parameters, credentialsToken)
+	parameters := workflow.NewParameters(environmentVariablesString, executeCommand, executeContainerImageURI, cwr.TargetName, cwr.ProjectName, cwr.Parameters, credentialsToken, cwr.Type)
 
 	workflowLabels := map[string]string{txIDHeader: r.Header.Get(txIDHeader)}
 

--- a/service/internal/workflow/workflow.go
+++ b/service/internal/workflow/workflow.go
@@ -198,7 +198,7 @@ func (a ArgoWorkflow) Submit(ctx context.Context, from string, parameters map[st
 }
 
 // NewParameters creates workflow parameters.
-func NewParameters(environmentVariablesString, executeCommand, executeContainerImageURI, targetName, projectName string, cliParameters map[string]string, credentialsToken string) map[string]string {
+func NewParameters(environmentVariablesString, executeCommand, executeContainerImageURI, targetName, projectName string, cliParameters map[string]string, credentialsToken string, flowType string) map[string]string {
 	parameters := map[string]string{
 		"environment_variables_string": environmentVariablesString,
 		"execute_command":              executeCommand,
@@ -206,6 +206,7 @@ func NewParameters(environmentVariablesString, executeCommand, executeContainerI
 		"project_name":                 projectName,
 		"target_name":                  targetName,
 		"credentials_token":            credentialsToken,
+		"type":                         flowType,
 	}
 
 	// this include override parameters

--- a/service/internal/workflow/workflow_test.go
+++ b/service/internal/workflow/workflow_test.go
@@ -224,3 +224,68 @@ func TestArgoSubmit(t *testing.T) {
 		})
 	}
 }
+
+func TestNewParameters(t *testing.T) {
+	environmentVariablesString := "ENVIRONMENT: prd"
+	executeCommand := "fake_execution_command"
+	executeContainerImageURI := "fake_execute_container_image_url"
+	targetName := "fake_target_name"
+	projectName := "fake_project_name"
+	preContainerImageURI := "fake_pre_container_image_uri"
+	credentialsToken := "fake_token"
+	flowType := "sync"
+
+	tests := []struct {
+		name                       string
+		environmentVariablesString string
+		executeCommand             string
+		executeContainerImageURI   string
+		targetName                 string
+		projectName                string
+		cliParameters              map[string]string
+		credentialsToken           string
+		flowType                   string
+		expected                   map[string]string
+	}{
+		{
+			name:                       "new parameter",
+			environmentVariablesString: environmentVariablesString,
+			executeCommand:             executeCommand,
+			executeContainerImageURI:   executeContainerImageURI,
+			targetName:                 targetName,
+			projectName:                projectName,
+			cliParameters:              map[string]string{"pre_container_image_uri": preContainerImageURI},
+			credentialsToken:           credentialsToken,
+			flowType:                   flowType,
+			expected: map[string]string{
+				"environment_variables_string": environmentVariablesString,
+				"execute_command":              executeCommand,
+				"execute_container_image_uri":  executeContainerImageURI,
+				"project_name":                 projectName,
+				"target_name":                  targetName,
+				"credentials_token":            credentialsToken,
+				"type":                         flowType,
+				"pre_container_image_uri":      preContainerImageURI,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parameters := NewParameters(
+				tt.environmentVariablesString,
+				tt.executeCommand,
+				tt.executeContainerImageURI,
+				tt.targetName,
+				tt.projectName,
+				tt.cliParameters,
+				tt.credentialsToken,
+				tt.flowType,
+			)
+
+			if !cmp.Equal(parameters, tt.expected) {
+				t.Errorf("\nwant: %v\n got: %v", tt.expected, parameters)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add an operation type (bootstrap/sync) to argo workflow so the workflow can know what it is running and decide what steps can be triggered.