### PR TITLE
chore: correcting context in workflow mocks

### DIFF
--- a/service/internal/workflow/workflow_test.go
+++ b/service/internal/workflow/workflow_test.go
@@ -80,7 +80,7 @@ func TestArgoWorkflowsListStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockClient := &mockArgoWorkflowAPIClient.WorkflowServiceClient{}
-			mockClient.On("ListWorkflows", mock.AnythingOfType("*context.emptyCtx"), mock.AnythingOfType("*workflow.WorkflowListRequest")).
+			mockClient.On("ListWorkflows", mock.AnythingOfType("context.backgroundCtx"), mock.AnythingOfType("*workflow.WorkflowListRequest")).
 				Return(tt.workflowListResp, tt.listWorkflowsErr)
 
 			argoWf := NewArgoWorkflow(
@@ -146,7 +146,7 @@ func TestArgoStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockClient := &mockArgoWorkflowAPIClient.WorkflowServiceClient{}
-			mockClient.On("GetWorkflow", mock.AnythingOfType("*context.emptyCtx"), mock.AnythingOfType("*workflow.WorkflowGetRequest")).
+			mockClient.On("GetWorkflow", mock.AnythingOfType("context.backgroundCtx"), mock.AnythingOfType("*workflow.WorkflowGetRequest")).
 				Return(tt.getWorkflowResp, tt.getWorkflowErr)
 
 			argoWf := NewArgoWorkflow(
@@ -203,7 +203,7 @@ func TestArgoSubmit(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockClient := &mockArgoWorkflowAPIClient.WorkflowServiceClient{}
-			mockClient.On("SubmitWorkflow", mock.AnythingOfType("*context.emptyCtx"), mock.AnythingOfType("*workflow.WorkflowSubmitRequest")).
+			mockClient.On("SubmitWorkflow", mock.AnythingOfType("context.backgroundCtx"), mock.AnythingOfType("*workflow.WorkflowSubmitRequest")).
 				Return(tt.submitWorkflowResp, tt.submitWorkflowErr)
 
 			argoWf := NewArgoWorkflow(


### PR DESCRIPTION
Seeing errors like below when running the unit tests. Changed the context type from empty to background.

```
mock: Unexpected Method Call
-----------------------------

GetWorkflow(context.backgroundCtx,*workflow.WorkflowGetRequest)
		0: context.backgroundCtx{emptyCtx:context.emptyCtx{}}
		1: &workflow.WorkflowGetRequest{Name:"testWorkflow1", Namespace:"namespace", GetOptions:(*v1.GetOptions)(nil), Fields:"", XXX_NoUnkeyedLiteral:struct {}{}, XXX_unrecognized:[]uint8(nil), XXX_sizecache:0}

The closest call I have is: 

GetWorkflow(mock.AnythingOfTypeArgument,mock.AnythingOfTypeArgument)
		0: "*context.emptyCtx"
		1: "*workflow.WorkflowGetRequest"


Diff: 0: FAIL:  type *context.emptyCtx != type backgroundCtx - (context.backgroundCtx=context.Background)
```