### PR TITLE
feat: add db comparison logic/logging for projects and tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+* Add db comparison logic/logging for project/token data
+
 ## [0.21.0]
 ### Changed
 * Add initial support for silently writing to DynamoDB

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -1248,8 +1248,14 @@ func (h handler) createToken(w http.ResponseWriter, r *http.Request) {
 
 	// List tokens from ddb, continue execution even if it fails
 	level.Debug(l).Log("message", "listing tokens from ddb")
-	if _, err := h.ddbClient.ListTokenEntries(ctx, projectName); err != nil {
+	ddbTokens, err := h.ddbClient.ListTokenEntries(ctx, projectName)
+	if err != nil {
 		level.Warn(l).Log("message", "error listing tokens from ddb", "db-type", "dynamo", "error", err)
+	} else {
+		// Compare results
+		if matches, diff := compareEntries(tokens, ddbTokens); !matches {
+			level.Warn(l).Log("message", "token list data mismatch", "data-type", "token-list", "diff", diff)
+		}
 	}
 
 	if len(tokens) >= numOfTokensLimit {
@@ -1339,8 +1345,14 @@ func (h handler) listTokens(w http.ResponseWriter, r *http.Request) {
 
 	// Get tokens from ddb, continue execution even if it fails
 	level.Debug(l).Log("message", "listing tokens from ddb")
-	if _, err := h.ddbClient.ListTokenEntries(ctx, projectName); err != nil {
+	ddbTokens, err := h.ddbClient.ListTokenEntries(ctx, projectName)
+	if err != nil {
 		level.Warn(l).Log("message", "error listing project tokens from ddb", "db-type", "dynamo", "error", err)
+	} else {
+		// Compare results
+		if matches, diff := compareEntries(tokens, ddbTokens); !matches {
+			level.Warn(l).Log("message", "token list data mismatch", "data-type", "token-list", "diff", diff)
+		}
 	}
 
 	resp := []responses.ListTokens{}

--- a/service/handlers_test.go
+++ b/service/handlers_test.go
@@ -1987,3 +1987,95 @@ func loadJSON(t *testing.T, filename string) (output interface{}) {
 	}
 	return output
 }
+
+func TestCompareEntries(t *testing.T) {
+	tests := []struct {
+		name     string
+		entryA   db.ProjectEntry
+		entryB   db.ProjectEntry
+		expected bool
+		hasDiff  bool
+	}{
+		{
+			name: "identical entries should match",
+			entryA: db.ProjectEntry{
+				ProjectID:  "test-project",
+				Repository: "https://github.com/test/repo",
+			},
+			entryB: db.ProjectEntry{
+				ProjectID:  "test-project",
+				Repository: "https://github.com/test/repo",
+			},
+			expected: true,
+		},
+		{
+			name: "different project ID should not match",
+			entryA: db.ProjectEntry{
+				ProjectID:  "project-a",
+				Repository: "https://github.com/test/repo",
+			},
+			entryB: db.ProjectEntry{
+				ProjectID:  "project-b",
+				Repository: "https://github.com/test/repo",
+			},
+			expected: false,
+			hasDiff:  true,
+		},
+		{
+			name: "different repository should not match",
+			entryA: db.ProjectEntry{
+				ProjectID:  "test-project",
+				Repository: "https://github.com/test/repo-a",
+			},
+			entryB: db.ProjectEntry{
+				ProjectID:  "test-project",
+				Repository: "https://github.com/test/repo-b",
+			},
+			expected: false,
+			hasDiff:  true,
+		},
+		{
+			name: "both fields different should not match",
+			entryA: db.ProjectEntry{
+				ProjectID:  "project-a",
+				Repository: "https://github.com/test/repo-a",
+			},
+			entryB: db.ProjectEntry{
+				ProjectID:  "project-b",
+				Repository: "https://github.com/test/repo-b",
+			},
+			expected: false,
+			hasDiff:  true,
+		},
+		{
+			name:     "empty entries should match",
+			entryA:   db.ProjectEntry{},
+			entryB:   db.ProjectEntry{},
+			expected: true,
+		},
+		{
+			name: "one empty entry should not match",
+			entryA: db.ProjectEntry{
+				ProjectID:  "test-project",
+				Repository: "https://github.com/test/repo",
+			},
+			entryB:   db.ProjectEntry{},
+			expected: false,
+			hasDiff:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches, diff := compareEntries(tt.entryA, tt.entryB)
+
+			assert.Equal(t, tt.expected, matches, "Expected matches to be %v", tt.expected)
+
+			if tt.hasDiff {
+				assert.NotEmpty(t, diff, "Expected non-empty diff when entries don't match")
+			} else {
+				assert.Empty(t, diff, "Expected empty diff when entries match")
+			}
+		})
+	}
+}


### PR DESCRIPTION
This does not perform comparison on deletes as we're not interested in the actual data at that point. Just that the actual project or token is removed.